### PR TITLE
feat: 增加 Action 自动打包 Docker 镜像

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+.gitignore
+*.md
+dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,10 @@ jobs:
 
       - name: setup buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms:
+           - linux/arm64
+           - linux/arm/v8
 
       - name: docker login
         uses: docker/login-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,6 @@ jobs:
 
       - name: setup buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          platforms:
-           - linux/arm64
-           - linux/arm/v8
 
       - name: docker login
         uses: docker/login-action@v3
@@ -53,5 +49,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: all
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup qemu
+        uses: docker/setup-qemu-action@v3
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: docker login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: publish
+        uses: docker/build-push-action@v5
+        id: publish
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ jobs:
       contents: read
       packages: write
 
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -48,7 +52,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: ${{matrix.platform}}
           push: true
-          platforms: all
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN corepack enable
 WORKDIR /app
 COPY . ./
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --no-frozen-lockfile
 
 EXPOSE 9100
 EXPOSE 9101

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:18-alpine
+# 开启 pnpm
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+# 拷贝文件
+WORKDIR /app
+COPY . ./
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+
+EXPOSE 9100
+EXPOSE 9101
+
+CMD ["node", "service.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+services:
+  script-hub:
+    image: "ghcr.io/script-hub-org/script-hub:latest"
+    ports:
+      - "9100:9100"
+      - "9101:9101"
+    environment:
+      # - "PORT=9100"
+      # - "BETA_PORT=9101"
+      # - "HOST=0.0.0.0"
+      # - "BASE_URL=https://xxx.com"
+      # - "BETA_BASE_URL=https:beta.//xxx.com"

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "nodemon": "^3.0.0",
     "tough-cookie": "^4.0.0",
     "vm2": "^3.9.19"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
增加 Docker 支持，提交代码自动打包 Docker 镜像到仓库 Packages

下面是docker运行命令，镜像地址 `ghcr.io/script-hub-org/script-hub:latest` 目前是根据规则写的，可能会有错误。
```bash
docker run -p 9100:9100 -p 9101:9101 -e HOST="0.0.0.0" --name ScriptHub ghcr.io/script-hub-org/script-hub:latest
```