### PR TITLE
修复 Surge 模块转换为 Loon 插件时 arguments 双引号丢失问题

### DIFF
--- a/Rewrite-Parser.beta.js
+++ b/Rewrite-Parser.beta.js
@@ -1090,7 +1090,7 @@ if (binaryInfo != null && binaryInfo.length > 0) {
     let sgargArr = []
     for (let i = 0; i < sgArg.length; i++) {
       let key = sgArg[i].key
-      let value = sgArg[i].value.split(',')[0].trim()
+      let value = sgArg[i].value.split(',')[0].trim().replace(/^"(.+)"$/, '$1') // 去掉引号用于 Surge 输出
       let a = key + ':' + value
       sgargArr.push(a)
     }
@@ -1906,7 +1906,7 @@ ${providers}
     body = body.replaceAll('{{{', '{').replaceAll('}}}', '}')
     for (let i = 0; i < sgArg.length; i++) {
       let e = '{' + sgArg[i].key + '}'
-      let r = sgArg[i].value.split(',')[0]
+      let r = sgArg[i].value.split(',')[0].replace(/^"(.+)"$/, '$1') // 去掉引号用于变量替换
       body = body.replaceAll(e, r)
     } //for
   } else if (isSurgeiOS || isShadowrocket) {
@@ -2399,11 +2399,12 @@ function parseArguments(str) {
 
     while ((match = regex.exec(queryString))) {
       const key = match[1].trim().replace(/^"(.+)"$/, '$1') //去除头尾空白符和引号
-      const value = match[2].trim().replace(/^"(.+)"$/, '$1') //去除头尾空白符和引号
+      const originalValue = match[2].trim() //保留原始值（包括双引号）
+      const value = originalValue.replace(/^"(.+)"$/, '$1') //去除头尾空白符和引号用于类型判断
       const type = /^(true|false)$/.test(value) ? 'switch' : 'input'
       const tag = `tag=${key}, desc=${key}`
 
-      sgArg.push({ key, value, type, tag }) //将键值对添加到对象中
+      sgArg.push({ key, value: originalValue, type, tag }) //将键值对添加到对象中，保留原始值
 
       if (value == 'hostname') {
         hn2 = true


### PR DESCRIPTION
## 问题描述
当 Surge 模块包含 `!arguments=Mock:"https://example.com"` 时，转换为 Loon 插件后双引号会丢失

## 修复内容
- 修改 parseArguments 函数保留原始值（包括双引号）
- 在 Surge 输出和变量替换时去掉引号  
- 在 Loon 输出时保留双引号
- 只修改了 beta 版本文件

## 测试用例
**原始：** `Mock:"https://mock.forward1.workers.dev/forward"`
**修复前：** `Mock=input,https://mock.forward1.workers.dev/forward,tag=Mock, desc=Mock`
**修复后：** `Mock=input,"https://mock.forward1.workers.dev/forward",tag=Mock, desc=Mock`

## 已知限制
此修复解决了 arguments 双引号丢失问题，但 Loon 插件仍不支持 `{{{Mock}}}` 变量替换语法。
用户需要手动将重写规则中的变量替换为实际值，例如：
- Surge: `^https://example.com {{{Mock}}}/path`
- Loon: `^https://example.com https://mock.forward1.workers.dev/forward/path`

## 修改文件
- `Rewrite-Parser.beta.js`
